### PR TITLE
Updated API to v 3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Please do! See CONTRIBUTING.md
 ## Credit
 
 Largely inspired by:
-* The blog post by [Dave Bouwman](https://github.com/dbouwman) on [Automated Headless Unit Tests with Esri JS API](http://blog.davebouwman.com/2019/07/26/automated-headless-unit-tests-with-esri-js-api/) using [Jasmine](https://jasmine.github.io/), Grunt, and PhantomJS
+* The blog post by [Dave Bouwman](https://github.com/dbouwman) on [Automated Headless Unit Tests with Esri JS API](http://blog.davebouwman.com/2013/07/26/automated-headless-unit-tests-with-esri-js-api/) using [Jasmine](https://jasmine.github.io/), Grunt, and PhantomJS
 * The tutorial by [David Spriggs](https://github.com/DavidSpriggs) on [using the intern with the ArcGIS API for JavaScript](https://github.com/DavidSpriggs/intern-tutorial-esri-jsapi) repo
 * [Scott Davis](https://twitter.com/ScottAGRC) and [Rene Rubalcava](https://twitter.com/odoenet) who graciously share their outstanding ideas and code
 

--- a/README.md
+++ b/README.md
@@ -265,30 +265,46 @@ This tutorial relies on the [karma-dojo plugin](https://github.com/karma-runner/
 After insalling and configuring the plug in, the trick is to set the `dojoConfig` in main.js to use the [ArcGIS API for JavaScript](http://js.arcgis.com) for the Dojo and Esri packages as follows:
 
 ```
-var dojoConfig = {
+  window.dojoConfig = {
     packages: [
-        // local pacakges to test
-        {
-            name:"esri-utils",
-            location:"/base/src/esri-utils"
-        },
-        // hosted packages
-        {
-            name: 'esri',
-            location: 'http://js.arcgis.com/3.13/esri'
-        }, {
-            name: 'dojo',
-            location: 'http://js.arcgis.com/3.13/dojo'
-        }, {
-            name: 'dojox',
-            location: 'http://js.arcgis.com/3.13/dojox'
-        }, {
-            name: 'dijit',
-            location: 'http://js.arcgis.com/3.13/dijit'
-        }
+      // local pacakges to test
+      {
+          name:"esri-utils",
+          location:"/base/src/esri-utils"
+      },
+
+      // esri/dojo packages
+      {
+        name: 'dgrid',
+        location: 'http://js.arcgis.com/3.20/dgrid'
+      }, {
+        name: 'dijit',
+        location: 'http://js.arcgis.com/3.20/dijit'
+      }, {
+        name: 'esri',
+        location: 'http://js.arcgis.com/3.20/esri'
+      }, {
+        name: 'dojo',
+        location: 'http://js.arcgis.com/3.20/dojo'
+      }, {
+        name: 'dojox',
+        location: 'http://js.arcgis.com/3.20/dojox'
+      }, {
+        name: 'put-selector',
+        location: 'http://js.arcgis.com/3.20/put-selector'
+      }, {
+        name: 'util',
+        location: 'http://js.arcgis.com/3.20/util'
+      }, {
+        name: 'xstyle',
+        location: 'http://js.arcgis.com/3.20/xstyle'
+      }, {
+        name: 'moment',
+        location: 'http://js.arcgis.com/3.20/moment',
+      }
     ],
     async: true
-};
+  };
 
 ```
 
@@ -296,7 +312,7 @@ var dojoConfig = {
 
 ### Dependencies
 
-* [ArcGIS API for JavaScript](http://js.arcgis.com): built/tested on v3.6 and updated to latest; may work w/ earlier versions.
+* [ArcGIS API for JavaScript](http://js.arcgis.com): built/tested on v3.20 and updated to latest; may work w/ earlier versions.
 
 And the latest versions of:
 * [Node](http://nodejs.org/)
@@ -328,7 +344,7 @@ Please do! See CONTRIBUTING.md
 ## Credit
 
 Largely inspired by:
-* The blog post by [Dave Bouwman](https://github.com/dbouwman) on [Automated Headless Unit Tests with Esri JS API](http://blog.davebouwman.com/2013/07/26/automated-headless-unit-tests-with-esri-js-api/) using [Jasmine](https://jasmine.github.io/), Grunt, and PhantomJS
+* The blog post by [Dave Bouwman](https://github.com/dbouwman) on [Automated Headless Unit Tests with Esri JS API](http://blog.davebouwman.com/2019/07/26/automated-headless-unit-tests-with-esri-js-api/) using [Jasmine](https://jasmine.github.io/), Grunt, and PhantomJS
 * The tutorial by [David Spriggs](https://github.com/DavidSpriggs) on [using the intern with the ArcGIS API for JavaScript](https://github.com/DavidSpriggs/intern-tutorial-esri-jsapi) repo
 * [Scott Davis](https://twitter.com/ScottAGRC) and [Rene Rubalcava](https://twitter.com/odoenet) who graciously share their outstanding ideas and code
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-karma-tutorial",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A demonstration of how to use the Karma test runner to automatically run Jasmine BDD-style unit tests on your ArcGIS API for JavaScript code.",
   "main": "spec/main.js",
   "keywords": [

--- a/spec/main.js
+++ b/spec/main.js
@@ -21,28 +21,31 @@
       // esri/dojo packages
       {
         name: 'dgrid',
-        location: 'http://js.arcgis.com/3.13/dgrid'
+        location: 'http://js.arcgis.com/3.20/dgrid'
       }, {
         name: 'dijit',
-        location: 'http://js.arcgis.com/3.13/dijit'
+        location: 'http://js.arcgis.com/3.20/dijit'
       }, {
         name: 'esri',
-        location: 'http://js.arcgis.com/3.13/esri'
+        location: 'http://js.arcgis.com/3.20/esri'
       }, {
         name: 'dojo',
-        location: 'http://js.arcgis.com/3.13/dojo'
+        location: 'http://js.arcgis.com/3.20/dojo'
       }, {
         name: 'dojox',
-        location: 'http://js.arcgis.com/3.13/dojox'
+        location: 'http://js.arcgis.com/3.20/dojox'
       }, {
         name: 'put-selector',
-        location: 'http://js.arcgis.com/3.13/put-selector'
+        location: 'http://js.arcgis.com/3.20/put-selector'
       }, {
         name: 'util',
-        location: 'http://js.arcgis.com/3.13/util'
+        location: 'http://js.arcgis.com/3.20/util'
       }, {
         name: 'xstyle',
-        location: 'http://js.arcgis.com/3.13/xstyle'
+        location: 'http://js.arcgis.com/3.20/xstyle'
+      }, {
+        name: 'moment',
+        location: 'http://js.arcgis.com/3.20/moment',
       }
     ],
     async: true


### PR DESCRIPTION
I could not get Karma to run using API versions >= 3.19, as it couldn't load the moment.js module and was giving the error:
```
Chrome 56.0.2924 (Windows 10 0.0.0) ERROR: 'There is no timestamp for /base/node_modules/karma-dojo/moment/moment.js!'
25 03 2017 18:24:28.562:WARN [web-server]: 404: /base/node_modules/karma-dojo/moment/moment.js
``` 
Adding moment.js to the dojoConfig solved the problem, and it should have no impact if people wish to use previous versions.